### PR TITLE
Unknown 'not' keyword with VS2019 by default

### DIFF
--- a/range.hpp
+++ b/range.hpp
@@ -32,7 +32,7 @@ struct range_iter_base : std::iterator<std::input_iterator_tag, T> {
     }
 
     bool operator !=(range_iter_base const& other) const {
-        return not (*this == other);
+        return !(*this == other);
     }
 
 protected:
@@ -72,7 +72,7 @@ struct range_proxy {
             }
 
             bool operator !=(iter const& other) const {
-                return not (*this == other);
+                return !(*this == other);
             }
 
         private:


### PR DESCRIPTION
When compiling cpp11-range with Visual Studio 2019, I got a compiler error related to the usage of the `not` operator. This problem never happened with VS2017.

Reading the [documentation](https://docs.microsoft.com/en-us/cpp/cpp/logical-negation-operator-exclpt?view=vs-2019#operator-keyword-for-) of Visual Studio 2019, the usage of the not operator is not enabled by default. This PR proposes then to use the logical negation operator (`!`) instead of have to include the header `<iso646.h>` or the compiler option `/Za`.